### PR TITLE
Stop operations that modify the system when root.

### DIFF
--- a/chaser/chaser.py
+++ b/chaser/chaser.py
@@ -25,6 +25,10 @@ def get_source_files(args, workingdir=None):
         pkgnames = args
         workingdir = workingdir or BUILD_DIR
 
+    if os.getuid() == 0:
+        print('Downloading sources as root is not allowed. Exiting.')
+        return
+
     if not os.path.exists(workingdir):
         os.mkdir(workingdir)
 
@@ -94,6 +98,10 @@ def install(args):
     except AttributeError:
         pkgnames = args
         workingdir = BUILD_DIR
+
+    if os.getuid() == 0:
+        print('Installations as root are not allowed. Exiting.')
+        return
 
     print(_("resolving dependencies..."))
 
@@ -173,6 +181,10 @@ def list_updates(args=None):
 
 def update(args):
     """Install updates"""
+    if os.getuid() == 0:
+        print('Updates as root are not allowed. Exiting.')
+        return
+
     print(termcolor.colored(":: ", 'blue', attrs=['bold']) + \
           termcolor.colored(_("Checking for updates..."), attrs=['bold']))
     updates = check_updates()


### PR DESCRIPTION
```makepkg``` does not allow to build packages as root, and makes chaser quit.

Checking early has a benefit: if we wait until ```makepkg``` is invoked, operations such as creating the cache directory or downloading packages are done as root. When the user reruns chaser without root privileges, errors are returned because some files are not accessible. The user then needs to intervene on them manually. This has happened to me a few times because I use pacman much more often than chaser.